### PR TITLE
fix: fixes issue of query showing registered events of other users

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -13,11 +13,12 @@ export const fetchEventsForUser = async (
   sortBy: string | undefined,
 ) => {
   const user = await auth();
+  const limit = 16;
 
   if (!user.userId) {
     const eventsData = await getPaginatedAllEvents(
       pageNumber,
-      16,
+      limit,
       orderBy,
       sortBy,
     );
@@ -27,7 +28,7 @@ export const fetchEventsForUser = async (
   const eventsData = await getPaginatedUnregisteredEvents(
     user.userId,
     pageNumber,
-    16,
+    limit,
     orderBy,
     sortBy,
   );


### PR DESCRIPTION
due to incorrect logic within the left join and where clauses, duplication was shown in the EventList as all registrations where joined into the query, not just those of the specified userId

Improved performance but utilising Promise.all to get the totalPages and EventsData at the simultaneously, rather than sequentially